### PR TITLE
Configure Vite base for Vercel deployments

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/italian-flashcards/',
+  base: process.env.VERCEL ? '/' : '/italian-flashcards/',
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- configure Vite base path to use '/' when deployed on Vercel

## Testing
- `npm run lint`
- `npm run build`
- `npx vercel --prod` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7f92d5c8321a6ee53e541df1a04