### PR TITLE
Add scripts to start app locally on Linux and Windows

### DIFF
--- a/start-linux.sh
+++ b/start-linux.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Start the Italian flashcards app locally on Linux
+set -e
+
+# Install dependencies if node_modules is missing
+if [ ! -d node_modules ]; then
+  npm install
+fi
+
+# Start Vite dev server and open the app in the browser
+npm run dev -- --open /italian-flashcards/

--- a/start-windows.ps1
+++ b/start-windows.ps1
@@ -1,0 +1,10 @@
+#!/usr/bin/env pwsh
+# Start the Italian flashcards app locally on Windows (PowerShell)
+
+# Install dependencies if node_modules is missing
+if (-not (Test-Path 'node_modules')) {
+    npm install
+}
+
+# Start Vite dev server and open the app in the browser
+npm run dev -- --open /italian-flashcards/


### PR DESCRIPTION
## Summary
- add start-linux.sh to run dev server on Linux
- add start-windows.ps1 for PowerShell on Windows

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bde9bf146c8321a03cf1bcc0931035