### PR TITLE
Fix E2E test timeout in auth spec

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -63,6 +63,9 @@ test.describe('Authentication Context Integration', () => {
     // Use various app features
     await page.getByRole('button', { name: 'Next' }).click();
     await page.getByRole('button', { name: 'Restart' }).click();
+
+    // Wait for the mode selection screen to appear after restart
+    await expect(page.getByText('Learn Russian from Italian')).toBeVisible();
     await page.getByText('Learn Russian from Italian').click();
 
     // No critical auth context errors should occur


### PR DESCRIPTION
## Summary
- Fixed timeout issue in `e2e/auth.spec.ts` where test was attempting to click 'Learn Russian from Italian' immediately after restart
- Added explicit wait with `await expect()` to ensure mode selection screen is visible before interaction
- Resolves GitHub Actions E2E test failures across all browsers (chromium, firefox, webkit)

## Test plan
- [x] E2E tests should now pass in GitHub Actions
- [x] No regression in existing test functionality
- [x] Proper wait for UI state transitions

🤖 Generated with [Claude Code](https://claude.ai/code)